### PR TITLE
Update index.js

### DIFF
--- a/components/Dropdown/index.js
+++ b/components/Dropdown/index.js
@@ -501,6 +501,7 @@ export default class Dropdown extends PureComponent {
               ref={this.updateScrollRef}
               data={itemData}
               style={[styles.scroll, scrollStyle]}
+              nestedScrollEnabled={true}
               renderItem={this.renderItem}
               keyExtractor={this.keyExtractor}
               scrollEnabled={visibleItemCount <= itemCount}


### PR DESCRIPTION
If autocomplete is placed inside a scrollview, the dropdown which internally has flatlist doesnot scroll in android. We need to specify in child components to inherit that feature with property 'nestedScrollEnabled'